### PR TITLE
bug fix for collect32.c

### DIFF
--- a/C/collect32.c
+++ b/C/collect32.c
@@ -90,9 +90,10 @@ main (void)
 
     shmem_barrier_all ();
 
-    shmem_collect32 (dst, src, me + 1, 0, 0, 4, pSync);
-
-    show_dst ("AFTER");
+    if (me < 4) {
+        shmem_collect32 (dst, src, me + 1, 0, 0, 4, pSync);
+        show_dst ("AFTER");
+    }
 
     shmem_finalize ();
 


### PR DESCRIPTION
Undefined behavior occurs for PEs that enter the shmem_collect32() that are not part of the Active Set, so we exclude them from entering the call with a branch.  Additionally, their destination output values are somewhat irrelevant, so they shouldn't call show_dst() either.
