### PR TITLE
bug fix for collect64.c

### DIFF
--- a/C/collect64.c
+++ b/C/collect64.c
@@ -91,9 +91,10 @@ main (void)
 
     shmem_barrier_all ();
 
-    shmem_collect64 (dst, src, me + 1, 0, 0, 4, pSync);
-
-    show_dst ("AFTER");
+    if (me < 4) {
+        shmem_collect64 (dst, src, me + 1, 0, 0, 4, pSync);
+        show_dst ("AFTER");
+    }
 
     shmem_finalize ();
 


### PR DESCRIPTION
This is the same issue with collec32.c Undefined behavior occurs for PEs that enter the shmem_collect64() that are not part of the Active Set, so we exclude them from entering the call with a branch.  Additionally, their destination output values are somewhat irrelevant, so they shouldn't call show_dst() either.
